### PR TITLE
Fix for files not copying over

### DIFF
--- a/lib/files.php
+++ b/lib/files.php
@@ -51,7 +51,9 @@ if( !class_exists( 'MUCD_Files' ) ) {
          * @param  string $dst destination directory path
          * @param  array  $exclude_dirs directories to ignore
          */
-        public static function recurse_copy($src,$dst, $exclude_dirs=array()) {
+        public static function recurse_copy($src, $dst, $exclude_dirs=array()) {
+            $src = rtrim( $src, '/' );
+            $dst = rtrim( $dst, '/' );
             $dir = opendir($src);
             @mkdir($dst);
             while(false !== ( $file = readdir($dir)) ) {


### PR DESCRIPTION
I ran into an interesting problem where the file copy failed, the passed `$src` and `$dst` variables in `recurse_copy()` had a trailing slash so file paths looked like `content/uploads//2018`.

This change adds a failsafe to make sure the paths are correct.

Some systems will interpret that path correctly but not in my case unfortunately.

Also if it helps I'm using a custom content directory which may have some bearing on the issue. Otherwise I'm not 100% sure why it would break like this.

```php
define( 'WP_HOME', 'https://' . $_SERVER['HTTP_HOST'] );
define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/content' );
define( 'WP_CONTENT_URL', WP_HOME . '/content' );
```